### PR TITLE
[RestLogger] Modify _logs array type in RestLogger class

### DIFF
--- a/src/abstractions/ILog.ts
+++ b/src/abstractions/ILog.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from "./LogLevel";
+import {LogLevel} from "./LogLevel";
 
 export interface ILog {
     method: string;

--- a/src/abstractions/IRestLoggerOptions.ts
+++ b/src/abstractions/IRestLoggerOptions.ts
@@ -1,8 +1,11 @@
+import {LogLevel} from "./LogLevel";
+
 export interface IRestLoggerOptions {
     environment: 'Development' | 'Staging' | 'Production',
     restLoggerUrl: string;
     batchLogIntervalInSeconds: number;
     timeoutInSeconds: number;
+    minimumLevel: LogLevel | null | undefined;
     service: {
         name: string;
         version: string;


### PR DESCRIPTION
This commit modifies the type of the `_logs` array in the `RestLogger` class. The array was originally storing objects of `IFullLog` type, but now it stores objects with properties `executionDate` and `log`, representing the execution date and the log respectively. This change allows for better organization and retrieval of log data.